### PR TITLE
Let darwin pass through the build constraints

### DIFF
--- a/contrib/seccomp/seccomp.go
+++ b/contrib/seccomp/seccomp.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
Even though we are letting seccomp to be build in darwin, we are ignoring them while the usage in docker engine.